### PR TITLE
Makefile: Update for APro 0.2.0-rc3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,15 @@ DOCKER_REGISTRY ?= localhost:31000
 DOCKER_IMAGE = $(DOCKER_REGISTRY)/amb-sidecar-plugin:$(shell git describe --tags --always --dirty)
 
 # The Go version must exactly match what was used to compile the amb-sidecar
-GO_VERSION = 1.11.4
+GO_VERSION = 1.12
+
+# In order to work with Alpine's musl libc6-compat, things must be
+# compiled for compatibility with LSB 3. Setting _FORTIFY_SOURCE=2
+# with GNU libc causes the CGO 1.12 runtime to require LSB 4.
+#
+# Some distros (including Ubuntu 14.04) patch their GCC to define
+# _FORTIFY_SOURCE=2 by default.
+export CGO_CPPFLAGS += -U_FORTIFY_SOURCE
 
 ifeq ($(shell go version),go version go$(GO_VERSION) linux/amd64)
 RUN =


### PR DESCRIPTION
In this morning's engineering huddle, I mentioned that Go 1.12 was released Monday evening, and if we're going to upgrade APro to it, before we cut 0.2.0 would be the time to do it; hence https://github.com/datawire/apro/pull/122

That also requires a bump to the Makefile here.

Since the most recent APro images (v0.2.0-rc2 and v0.2.0-jwt0) were built with Go 1.11, I'm waiting until there's actually an image built with 1.12 before merging this.