### PR TITLE
Bump APro version 0.2.2 → 0.2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REGISTRY ?= localhost:31000
 DOCKER_IMAGE = $(DOCKER_REGISTRY)/amb-sidecar-plugin:$(shell git describe --tags --always --dirty)
 
-APRO_VERSION = 0.2.2
+APRO_VERSION = 0.2.4
 
 apro-abi@%.txt:
 	curl --fail -o $@ https://s3.amazonaws.com/datawire-static-files/apro-abi/apro-abi@$(APRO_VERSION).txt


### PR DESCRIPTION
This apparently doesn't require any changes to go.mod