### PR TITLE
Bump APRO_VERSION 0.2.5 → 0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REGISTRY ?= localhost:31000
 DOCKER_IMAGE = $(DOCKER_REGISTRY)/amb-sidecar-plugin:$(shell git describe --tags --always --dirty)
 
-APRO_VERSION = 0.2.5
+APRO_VERSION = 0.3.0
 
 apro-abi@%.txt:
 	curl --fail -o $@ https://s3.amazonaws.com/datawire-static-files/apro-abi/apro-abi@$(APRO_VERSION).txt


### PR DESCRIPTION
It's the same release, just re-tagged at Richard's request.